### PR TITLE
Add libgomp1 to tesseract Dockerfile

### DIFF
--- a/tesseract/Dockerfile
+++ b/tesseract/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update \
                           git \
                           liblept4 \
                           libleptonica-dev \
+                          libgomp1 \
                           libtool \
     && git clone https://github.com/tesseract-ocr/tesseract.git \
         && cd tesseract \


### PR DESCRIPTION
This lib is required by tesseract for OpenMP support enabled by default.