### PR TITLE
Add modules and packages required to fully run.

### DIFF
--- a/cowrie/Dockerfile
+++ b/cowrie/Dockerfile
@@ -1,7 +1,3 @@
-#
-# Dockerfile for cowrie
-#
-
 FROM alpine
 MAINTAINER kev <noreply@datageek.info>
 
@@ -9,7 +5,12 @@ RUN apk add -U curl \
                py-pip \
                py-twisted \
                tar \
-    && pip install pyasn1 \
+               gcc \
+               python-dev \
+               musl-dev \
+               libffi-dev \
+               openssl-dev \
+    && pip install pyasn1 pyOpenSSL service_identity \
     && adduser -D cowrie \
     && cd /home/cowrie \
     && curl -sSL https://github.com/micheloosterhof/cowrie/archive/master.tar.gz | tar xz --strip 1 \
@@ -18,7 +19,7 @@ RUN apk add -U curl \
     && apk del curl \
                tar \
     && rm -rf /var/cache/apk/*
-    
+
 EXPOSE 2222
 
 USER cowrie


### PR DESCRIPTION
Current version of cowrie requires pyOpenSSL, and recommends service_identity.  Added requirements to Dockerfile to include these.