### PR TITLE
Corrected #14: Added PHP 'soap' extension for mantisbt SOAP API.

### DIFF
--- a/mantisbt/Dockerfile
+++ b/mantisbt/Dockerfile
@@ -9,10 +9,10 @@ RUN a2enmod rewrite
 
 RUN set -xe \
     && apt-get update \
-    && apt-get install -y libpng12-dev libjpeg-dev libpq-dev \
+    && apt-get install -y libpng12-dev libjpeg-dev libpq-dev libxml2-dev \
     && rm -rf /var/lib/apt/lists/* \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
-    && docker-php-ext-install gd mbstring mysql mysqli pgsql
+    && docker-php-ext-install gd mbstring mysql mysqli pgsql soap
 
 WORKDIR /var/www/html
 


### PR DESCRIPTION
Pull Request correcting #14 : 

The php soap extension is now installed using docker-php-ext-install.
Also added libxml2-dev on which the soap extension depends.

I tested on a VM running Ubuntu 14.04 with Docker 1.10.3, everything seems good. 