### PR TITLE
upgraded magento to 2.1.0 and resolved composer install issue

### DIFF
--- a/magento/Dockerfile
+++ b/magento/Dockerfile
@@ -6,7 +6,6 @@ FROM php:5.6-apache
 MAINTAINER kev<noreply@easypi.info>
 
 RUN a2enmod rewrite
-
 RUN set -xe \
     && apt-get update \
     && apt-get install -y libcurl3-dev \
@@ -18,8 +17,17 @@ RUN set -xe \
                           libmcrypt4 \
                           libpng12-dev \
                           libpng12-dev \
+                          libxslt-dev \
+                          zziplib-bin \
+                          zlib1g-dev \
+                          libicu-dev \
+                          g++ \
     && docker-php-ext-configure gd --with-png-dir=/usr --with-jpeg-dir=/usr \
+    && docker-php-ext-configure intl \
     && docker-php-ext-install gd mcrypt mbstring pdo_mysql \
+    && docker-php-ext-install intl \
+    && docker-php-ext-install xsl \
+    && docker-php-ext-install zip \
     && apt-get purge -y --auto-remove libcurl3-dev \
                                       libfreetype6-dev \
                                       libjpeg62-turbo-dev \
@@ -27,17 +35,18 @@ RUN set -xe \
                                       libpng12-dev \
                                       libpng12-dev \
     && rm -rf /var/lib/apt/lists/*
-
+RUN echo 'always_populate_raw_post_data = -1\nmax_execution_time = 240\nmax_input_vars = 1500\nupload_max_filesize = 32M\npost_max_size = 32M' > /usr/local/etc/php/conf.d/typo3.ini
+WORKDIR /usr/src
+RUN curl -sS https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer
 WORKDIR /var/www/html
-
-ENV MAGENTO_VER 2.0.1
-ENV MAGENTO_MD5 a3e35a6581cab5ce31d7bbc3a43ed70a
+ENV MAGENTO_VER 2.1.0
+ENV MAGENTO_MD5 aab11e6b443be7179410b195b2099819
 ENV MAGENTO_URL https://github.com/magento/magento2/archive/$MAGENTO_VER.tar.gz
 ENV MAGENTO_FILE magento.tar.gz
-
 RUN curl -sSL ${MAGENTO_URL} -o ${MAGENTO_FILE} \
     && echo "${MAGENTO_MD5}  ${MAGENTO_FILE}" | md5sum -c \
     && tar xzf ${MAGENTO_FILE} --strip 1 \
     && rm ${MAGENTO_FILE} \
-    && chown -R www-data:www-data .
-
+    && chown -R www-data:www-data . \
+    && /etc/init.d/apache2 restart \
+    && composer install

--- a/magento/docker-compose.yml
+++ b/magento/docker-compose.yml
@@ -1,13 +1,10 @@
 magento:
-  image: vimagick/magento
-  ports:
-    - "8000:80"
-  links:
-    - mysql
+  build: .
+  net: host
   restart: always
-
 mysql:
   image: mysql
+  net: host
   environment:
     - MYSQL_ROOT_PASSWORD=root
     - MYSQL_DATABASE=magento


### PR DESCRIPTION
Upgraded to Magento 2.1.0
Resolved the problem of autoloader error message.
Dockerfile runs the composer install.
After starting the container using `docker compose up` command user only needs to input `127.0.0.1` as database host.