### PR TITLE
minidlna is not the valid binary name

### DIFF
--- a/minidlna/Dockerfile
+++ b/minidlna/Dockerfile
@@ -15,4 +15,4 @@ WORKDIR /opt
 EXPOSE 1900/udp
 EXPOSE 8200/tcp
 
-CMD ["minidlna", "-d"]
+CMD ["minidlnad", "-d"]


### PR DESCRIPTION
Hi,
 Tried to use this image and realized that minidlna not anymore exists:
```
/opt # ls -l /usr/sbin/
[...]
-rwxr-xr-x    2 root     root        269464 Apr 29 22:44 minidlnad
```
So there is minidlnad instead.

Maybe the name changed recently:
https://pkgs.alpinelinux.org/contents?branch=v3.4&name=minidlna&arch=x86_64&repo=main