### PR TITLE
iptables: fix tc distribution directory

### DIFF
--- a/iptables/Dockerfile
+++ b/iptables/Dockerfile
@@ -5,7 +5,7 @@
 FROM alpine
 MAINTAINER kev <noreply@easypi.info>
 
-RUN apk add -U iproute2
+RUN apk add -U iproute2 && ln -s /usr/lib/tc /lib/tc
 
 ENV LIMIT_PORT 8388
 ENV LIMIT_CONN 5


### PR DESCRIPTION
Hi,

the `delay` command of `tc` fails as soon as you specify a specific `distribution` because the directory is wrong:

    No distribution data for normal (/lib/tc//normal.dist: No such file or directory)

Cheers,
Gregor