### PR TITLE
Update scrapyd.conf

### DIFF
--- a/scrapyd/scrapyd.conf
+++ b/scrapyd/scrapyd.conf
@@ -8,6 +8,7 @@ max_proc          = 0
 max_proc_per_cpu  = 4
 finished_to_keep  = 100
 poll_interval     = 5
+bind_address      = 0.0.0.0
 http_port         = 6800
 debug             = off
 runner            = scrapyd.runner


### PR DESCRIPTION
With the release of 1.2.0 at 2017-04-12 scrapyd’s bind_address now defaults to 127.0.0.1 instead of 0.0.0.0 to listen only for connection from the local host, but for docker environment it should be listened from outside so now we should set it manually.