### PR TITLE
allow verify certificate chain in client mode (optional)

### DIFF
--- a/stunnel/docker-entrypoint.sh
+++ b/stunnel/docker-entrypoint.sh
@@ -10,6 +10,8 @@ socket = l:TCP_NODELAY=1
 socket = r:TCP_NODELAY=1
 cert = /etc/stunnel/stunnel.pem
 client = ${CLIENT:-no}
+verifyChain = ${VERIFY_CHAIN:-no}
+CAfile = /etc/ssl/cert.pem
 
 [${SERVICE}]
 accept = ${ACCEPT}


### PR DESCRIPTION
* `verifyChain` allows stunnel to verify the remote certificate chain. the default is still no, so it should keep backwards compatibility.
* `CAfile` points to a file that should exist on Alpine and includes the root certificates. It has no effect unless `verifyChain` is set to yes.