### PR TITLE
dante: update sha256 checksum for upstream-repackaged 1.4.2 tarball

### DIFF
--- a/dante/Dockerfile
+++ b/dante/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER kev <noreply@easypi.pro>
 
 ENV DANTE_VER 1.4.2
 ENV DANTE_URL https://www.inet.no/dante/files/dante-$DANTE_VER.tar.gz
-ENV DANTE_SHA baa25750633a7f9f37467ee43afdf7a95c80274394eddd7dcd4e1542aa75caad
+ENV DANTE_SHA 4c97cff23e5c9b00ca1ec8a95ab22972813921d7fbf60fc453e3e06382fc38a7
 ENV DANTE_FILE dante.tar.gz
 ENV DANTE_TEMP dante
 ENV DANTE_DEPS build-essential curl


### PR DESCRIPTION
On 2018-05-17, Inferno Nettwerk re-packaged their 1.4.2 release of `dante`, and published the new sha256 checksum on their website: http://www.inet.no/dante/download.html

Currently, `docker build` fails for `dante` with the error:
```dante.tar.gz: FAILED
shasum: WARNING: 1 computed checksum did NOT match
```

This PR updates the checksum to the one published on the upstream website, which matches the current `dante-1.4.2.tar.gz` file. `docker build` now completes successfully.