### PR TITLE
Configurable routes for PPTP client

### DIFF
--- a/pptp/README.md
+++ b/pptp/README.md
@@ -13,6 +13,7 @@ pptp:
     - TUNNEL=vps
     - USERNAME=username
     - PASSWORD=password
+    - ROUTES=0.0.0.0/1 128.0.0.0/1
   net: host
   privileged: yes
   restart: unless-stopped

--- a/pptp/README.md
+++ b/pptp/README.md
@@ -19,6 +19,13 @@ pptp:
   restart: unless-stopped
 ```
 
+## available parameters (passed as environment variables)
+
+* `SERVER`: IP or hostname of the VPN server
+* `TUNNEL`: name of the tunnel
+* `USERNAME` / `PASSWORD`: auth info for the server
+* `ROUTES`: space separated list of routes that should be routed through the VPN. By default all traffic is routed
+
 ## up and running
 
 ```

--- a/pptp/docker-compose.yml
+++ b/pptp/docker-compose.yml
@@ -5,7 +5,6 @@ pptp:
     - TUNNEL=vps
     - USERNAME=username
     - PASSWORD=password
-    - ROUTES=0.0.0.0/1 128.0.0.0/1
   net: host
   privileged: yes
   restart: unless-stopped

--- a/pptp/docker-compose.yml
+++ b/pptp/docker-compose.yml
@@ -5,6 +5,7 @@ pptp:
     - TUNNEL=vps
     - USERNAME=username
     - PASSWORD=password
+    - ROUTES=0.0.0.0/1 128.0.0.0/1
   net: host
   privileged: yes
   restart: unless-stopped


### PR DESCRIPTION
Adds a parameter to docker-compose.yml for setting up routes manually instead of routing everything through the tunnel. This resolves #95 