### PR TITLE
fix the torrc client ClientTransportPlugin path

### DIFF
--- a/tor/README.md
+++ b/tor/README.md
@@ -63,10 +63,10 @@ UseBridges 1
 #Bridge meek 1.2.3.4:9001 url=https://meek.easypi.info:7002/
 #Bridge obfs3 1.2.3.4:9001 F24BF4DE74649E205A8A3621C84F97FF623B2083
 Bridge obfs4 1.2.3.4:9001 F24BF4DE74649E205A8A3621C84F97FF623B2083
-#ClientTransportPlugin fte exec /usr/local/bin/fteproxy
-#ClientTransportPlugin meek exec /usr/local/bin/meek-client
-#ClientTransportPlugin obfs3 exec /usr/local/bin/obfsproxy
-ClientTransportPlugin obfs4 exec /usr/local/bin/obfs4proxy
+#ClientTransportPlugin fte exec /usr/bin/fteproxy
+#ClientTransportPlugin meek exec /usr/bin/meek-client
+#ClientTransportPlugin obfs3 exec /usr/bin/obfsproxy
+ClientTransportPlugin obfs4 exec /usr/bin/obfs4proxy
 ```
 
 > Please connect via `HTTPProxy`/`HTTPSProxy`/`Socks5Proxy` if you're blocked!


### PR DESCRIPTION
the binaries are installed under the `usr/bin` path [[1]](https://github.com/vimagick/dockerfiles/blob/master/tor/Dockerfile#L22)