### PR TITLE
Fixing missing dependency for pushover

### DIFF
--- a/urlwatch/Dockerfile
+++ b/urlwatch/Dockerfile
@@ -23,6 +23,7 @@ RUN set -xe \
                               minidb    \
                               pyyaml    \
                               requests  \
+                              chump     \
                               urlwatch  \
     && apk del build-base  \
                libffi-dev  \


### PR DESCRIPTION
Python dependency chump is required for pushover to work.