### PR TITLE
[urlwatch] add keyrings.alt library for smtp auth login support

### DIFF
--- a/urlwatch/Dockerfile
+++ b/urlwatch/Dockerfile
@@ -19,6 +19,7 @@ RUN set -xe \
     && python3 -m pip install appdirs   \
                               cssselect \
                               keyring   \
+                              keyrings.alt \
                               lxml      \
                               minidb    \
                               pyyaml    \


### PR DESCRIPTION
Hi,
this fix urlwatch smtp auth login support.
Thanks