### PR TITLE
Removed version constrain

### DIFF
--- a/youtube/youtube-dl/Dockerfile
+++ b/youtube/youtube-dl/Dockerfile
@@ -11,7 +11,10 @@ RUN set -xe \
                           openssl \
                           python3 \
                           aria2 \
-    && pip3 install youtube-dl==2018.09.26
+    && pip3 install youtube-dl
+
+# Try to run it so we know it works
+RUN youtube-dl --version
 
 WORKDIR /data
 


### PR DESCRIPTION
youtube-dl is very sensitive to outdating, so it is better to have it always updated.

Added test so receipe will fail if not installed correctly.