### PR TITLE
don't re-initialize nodes, even if they are not named "server"

### DIFF
--- a/tinc/init.sh
+++ b/tinc/init.sh
@@ -3,7 +3,7 @@
 # initialize server profile
 #
 
-if [ -f /etc/tinc/${NETNAME}/hosts/server ]
+if [ -f /etc/tinc/${NETNAME}/rsa_key.priv ]
 then
     echo 'Initialized!'
     exit 0


### PR DESCRIPTION
I made this modification because I wanted to use this dockerfile in an existing tinc network that is already configured. I might edit it further to adapt it to more situations.