### PR TITLE
Install openssl

### DIFF
--- a/stunnel/Dockerfile
+++ b/stunnel/Dockerfile
@@ -6,7 +6,7 @@ FROM alpine:3
 
 MAINTAINER EasyPi Software Foundation
 
-RUN apk add --no-cache stunnel libressl
+RUN apk add --no-cache stunnel libressl openssl
 
 COPY docker-entrypoint.sh /entrypoint.sh
 


### PR DESCRIPTION
Since the docker-entrypoint.sh attempts to create a cert, we need to have openssl installed