### PR TITLE
Add a missing dependency

### DIFF
--- a/taskd/Dockerfile
+++ b/taskd/Dockerfile
@@ -11,6 +11,7 @@ RUN apk add --update build-base \
                      cmake \
                      gnutls \
                      gnutls-dev \
+                     gnutls-utils \
                      libstdc++ \
     && wget -O- http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz | tar xz \
         && cd libuuid-1.0.3 \


### PR DESCRIPTION
# Environment
Docker version 19.03.8, build afacb8b7f0

# Log
```
~/dockerfiles/taskd $ docker build .

Sending build context to Docker daemon  9.728kB
Step 1/8 : FROM alpine
latest: Pulling from library/alpine
df20fa9351a1: Pull complete 
Digest: sha256:185518070891758909c9f839cf4ca393ee977ac378609f700f60a771a2dfe321
Status: Downloaded newer image for alpine:latest
 ---> a24bb4013296
Step 2/8 : MAINTAINER kev <noreply@easypi.pro>
 ---> Running in a9f8f2021f9f
Removing intermediate container a9f8f2021f9f
 ---> ece194da3d96
Step 3/8 : ENV TASKDDATA /var/taskd
 ---> Running in 5bfd5068c401
Removing intermediate container 5bfd5068c401
 ---> 53c8a824c7ed
Step 4/8 : RUN apk add --update build-base                      cmake                      gnutls                      gnutls-dev                      libstdc++     && wget -O- http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz | tar xz         && cd libuuid-1.0.3         && ./configure --prefix=/usr         && make install         && cd ..         && rm -rf libuuid-1.0.3     && wget -O- http://taskwarrior.org/download/taskd-1.1.0.tar.gz | tar xz         && cd taskd-1.1.0         && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=release .         && make install         && cd pki         && ./generate         && mkdir -p $TASKDDATA         && mv *.pem $TASKDDATA         && cd ../..         && rm -rf taskd-1.1.0     && apk del --purge build-base                        cmake                        gnutls-dev     && rm -rf /var/cache/apk/*
 ---> Running in 5a7ac5456543
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/main/x86_64/APKINDEX.tar.gz
fetch http://dl-cdn.alpinelinux.org/alpine/v3.12/community/x86_64/APKINDEX.tar.gz
(1/51) Upgrading musl (1.1.24-r8 -> 1.1.24-r9)
(2/51) Installing libgcc (9.3.0-r2)
(3/51) Installing libstdc++ (9.3.0-r2)
(4/51) Installing binutils (2.34-r1)
(5/51) Installing libmagic (5.38-r0)
(6/51) Installing file (5.38-r0)
(7/51) Installing gmp (6.2.0-r0)
(8/51) Installing isl (0.18-r0)
(9/51) Installing libgomp (9.3.0-r2)
(10/51) Installing libatomic (9.3.0-r2)
(11/51) Installing libgphobos (9.3.0-r2)
(12/51) Installing mpfr4 (4.0.2-r4)
(13/51) Installing mpc1 (1.1.0-r1)
(14/51) Installing gcc (9.3.0-r2)
(15/51) Installing musl-dev (1.1.24-r9)
(16/51) Installing libc-dev (0.7.2-r3)
(17/51) Installing g++ (9.3.0-r2)
(18/51) Installing make (4.3-r0)
(19/51) Installing fortify-headers (1.1-r0)
(20/51) Installing patch (2.7.6-r6)
(21/51) Installing build-base (0.5-r2)
(22/51) Installing libacl (2.2.53-r0)
(23/51) Installing libbz2 (1.0.8-r1)
(24/51) Installing expat (2.2.9-r1)
(25/51) Installing lz4-libs (1.9.2-r0)
(26/51) Installing xz-libs (5.2.5-r0)
(27/51) Installing zstd-libs (1.4.5-r0)
(28/51) Installing libarchive (3.4.3-r1)
(29/51) Installing ca-certificates (20191127-r4)
(30/51) Installing nghttp2-libs (1.41.0-r0)
(31/51) Installing libcurl (7.69.1-r1)
(32/51) Installing ncurses-terminfo-base (6.2_p20200523-r0)
(33/51) Installing ncurses-libs (6.2_p20200523-r0)
(34/51) Installing rhash-libs (1.3.9-r1)
(35/51) Installing libuv (1.38.1-r0)
(36/51) Installing cmake (3.17.2-r0)
(37/51) Installing nettle (3.5.1-r1)
(38/51) Installing libffi (3.3-r2)
(39/51) Installing p11-kit (0.23.20-r5)
(40/51) Installing libtasn1 (4.16.0-r1)
(41/51) Installing libunistring (0.9.10-r0)
(42/51) Installing gnutls (3.6.15-r0)
(43/51) Installing gnutls-c++ (3.6.15-r0)
(44/51) Installing libgmpxx (6.2.0-r0)
(45/51) Installing pkgconf (1.7.2-r0)
(46/51) Installing gmp-dev (6.2.0-r0)
(47/51) Installing nettle-dev (3.5.1-r1)
(48/51) Installing libtasn1-progs (4.16.0-r1)
(49/51) Installing libtasn1-dev (4.16.0-r1)
(50/51) Installing p11-kit-dev (0.23.20-r5)
(51/51) Installing gnutls-dev (3.6.15-r0)
Executing busybox-1.31.1-r16.trigger
Executing ca-certificates-20191127-r4.trigger
OK: 260 MiB in 64 packages
Connecting to downloads.sourceforge.net (216.105.38.13:80)
Connecting to jaist.dl.sourceforge.net (150.65.7.130:443)
writing to stdout
-                    100% |********************************|  310k  0:00:00 ETA
written to stdout
checking for a BSD-compatible install... /usr/bin/install -c
checking whether build environment is sane... yes
checking for a thread-safe mkdir -p... ./install-sh -c -d
checking for gawk... no
checking for mawk... no
checking for nawk... no
checking for awk... awk
checking whether make sets $(MAKE)... yes
checking whether make supports nested variables... yes
checking build system type... x86_64-unknown-linux-gnu
checking host system type... x86_64-unknown-linux-gnu
checking how to print strings... printf
checking for style of include used by make... GNU
checking for gcc... gcc
checking whether the C compiler works... yes
checking for C compiler default output file name... a.out
checking for suffix of executables... 
checking whether we are cross compiling... no
checking for suffix of object files... o
checking whether we are using the GNU C compiler... yes
checking whether gcc accepts -g... yes
checking for gcc option to accept ISO C89... none needed
checking dependency style of gcc... gcc3
checking for a sed that does not truncate output... /bin/sed
checking for grep that handles long lines and -e... /bin/grep
checking for egrep... /bin/grep -E
checking for fgrep... /bin/grep -F
checking for ld used by gcc... /usr/x86_64-alpine-linux-musl/bin/ld
checking if the linker (/usr/x86_64-alpine-linux-musl/bin/ld) is GNU ld... yes
checking for BSD- or MS-compatible name lister (nm)... /usr/bin/nm -B
checking the name lister (/usr/bin/nm -B) interface... BSD nm
checking whether ln -s works... yes
checking the maximum length of command line arguments... 98304
checking whether the shell understands some XSI constructs... yes
checking whether the shell understands "+="... no
checking how to convert x86_64-unknown-linux-gnu file names to x86_64-unknown-linux-gnu format... func_convert_file_noop
checking how to convert x86_64-unknown-linux-gnu file names to toolchain format... func_convert_file_noop
checking for /usr/x86_64-alpine-linux-musl/bin/ld option to reload object files... -r
checking for objdump... objdump
checking how to recognize dependent libraries... pass_all
checking for dlltool... no
checking how to associate runtime and link libraries... printf %s\n
checking for ar... ar
checking for archiver @FILE support... @
checking for strip... strip
checking for ranlib... ranlib
checking command to parse /usr/bin/nm -B output from gcc object... ok
checking for sysroot... no
checking for mt... no
checking if : is a manifest tool... no
checking how to run the C preprocessor... gcc -E
checking for ANSI C header files... yes
checking for sys/types.h... yes
checking for sys/stat.h... yes
checking for stdlib.h... yes
checking for string.h... yes
checking for memory.h... yes
checking for strings.h... yes
checking for inttypes.h... yes
checking for stdint.h... yes
checking for unistd.h... yes
checking for dlfcn.h... yes
checking for objdir... .libs
checking if gcc supports -fno-rtti -fno-exceptions... no
checking for gcc option to produce PIC... -fPIC -DPIC
checking if gcc PIC flag -fPIC -DPIC works... yes
checking if gcc static flag -static works... yes
checking if gcc supports -c -o file.o... yes
checking if gcc supports -c -o file.o... (cached) yes
checking whether the gcc linker (/usr/x86_64-alpine-linux-musl/bin/ld -m elf_x86_64) supports shared libraries... yes
checking whether -lc should be explicitly linked in... no
checking dynamic linker characteristics... GNU/Linux ld.so
checking how to hardcode library paths into programs... immediate
checking whether stripping libraries is possible... yes
checking if libtool supports shared libraries... yes
checking whether to build shared libraries... yes
checking whether to build static libraries... yes
checking for gcc... (cached) gcc
checking whether we are using the GNU C compiler... (cached) yes
checking whether gcc accepts -g... (cached) yes
checking for gcc option to accept ISO C89... (cached) none needed
checking dependency style of gcc... (cached) gcc3
checking for library containing socket... none required
checking fcntl.h usability... yes
checking fcntl.h presence... yes
checking for fcntl.h... yes
checking for inttypes.h... (cached) yes
checking limits.h usability... yes
checking limits.h presence... yes
checking for limits.h... yes
checking netinet/in.h usability... yes
checking netinet/in.h presence... yes
checking for netinet/in.h... yes
checking for stdlib.h... (cached) yes
checking for string.h... (cached) yes
checking sys/file.h usability... yes
checking sys/file.h presence... yes
checking for sys/file.h... yes
checking sys/ioctl.h usability... yes
checking sys/ioctl.h presence... yes
checking for sys/ioctl.h... yes
checking sys/socket.h usability... yes
checking sys/socket.h presence... yes
checking for sys/socket.h... yes
checking sys/time.h usability... yes
checking sys/time.h presence... yes
checking for sys/time.h... yes
checking for unistd.h... (cached) yes
checking whether _SC_HOST_NAME_MAX is declared... yes
checking for int32_t... yes
checking for mode_t... yes
checking for size_t... yes
checking for ssize_t... yes
checking for uint16_t... yes
checking for uint32_t... yes
checking for uint64_t... yes
checking for uint8_t... yes
checking for ftruncate... yes
checking for gettimeofday... yes
checking for memset... yes
checking for socket... yes
checking for strtoul... yes
checking for usleep... yes
checking for srandom... yes
checking that generated files are newer than configure... done
configure: creating ./config.status
config.status: creating Makefile
config.status: creating uuid.pc
config.status: creating config.h
config.status: executing depfiles commands
config.status: executing libtool commands
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-clear.lo -MD -MP -MF .deps/libuuid_la-clear.Tpo -c -o libuuid_la-clear.lo `test -f 'clear.c' || echo './'`clear.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-clear.lo -MD -MP -MF .deps/libuuid_la-clear.Tpo -c clear.c  -fPIC -DPIC -o .libs/libuuid_la-clear.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-clear.lo -MD -MP -MF .deps/libuuid_la-clear.Tpo -c clear.c -o libuuid_la-clear.o >/dev/null 2>&1
mv -f .deps/libuuid_la-clear.Tpo .deps/libuuid_la-clear.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-compare.lo -MD -MP -MF .deps/libuuid_la-compare.Tpo -c -o libuuid_la-compare.lo `test -f 'compare.c' || echo './'`compare.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-compare.lo -MD -MP -MF .deps/libuuid_la-compare.Tpo -c compare.c  -fPIC -DPIC -o .libs/libuuid_la-compare.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-compare.lo -MD -MP -MF .deps/libuuid_la-compare.Tpo -c compare.c -o libuuid_la-compare.o >/dev/null 2>&1
mv -f .deps/libuuid_la-compare.Tpo .deps/libuuid_la-compare.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-copy.lo -MD -MP -MF .deps/libuuid_la-copy.Tpo -c -o libuuid_la-copy.lo `test -f 'copy.c' || echo './'`copy.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-copy.lo -MD -MP -MF .deps/libuuid_la-copy.Tpo -c copy.c  -fPIC -DPIC -o .libs/libuuid_la-copy.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-copy.lo -MD -MP -MF .deps/libuuid_la-copy.Tpo -c copy.c -o libuuid_la-copy.o >/dev/null 2>&1
mv -f .deps/libuuid_la-copy.Tpo .deps/libuuid_la-copy.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-gen_uuid.lo -MD -MP -MF .deps/libuuid_la-gen_uuid.Tpo -c -o libuuid_la-gen_uuid.lo `test -f 'gen_uuid.c' || echo './'`gen_uuid.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-gen_uuid.lo -MD -MP -MF .deps/libuuid_la-gen_uuid.Tpo -c gen_uuid.c  -fPIC -DPIC -o .libs/libuuid_la-gen_uuid.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-gen_uuid.lo -MD -MP -MF .deps/libuuid_la-gen_uuid.Tpo -c gen_uuid.c -o libuuid_la-gen_uuid.o >/dev/null 2>&1
mv -f .deps/libuuid_la-gen_uuid.Tpo .deps/libuuid_la-gen_uuid.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-isnull.lo -MD -MP -MF .deps/libuuid_la-isnull.Tpo -c -o libuuid_la-isnull.lo `test -f 'isnull.c' || echo './'`isnull.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-isnull.lo -MD -MP -MF .deps/libuuid_la-isnull.Tpo -c isnull.c  -fPIC -DPIC -o .libs/libuuid_la-isnull.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-isnull.lo -MD -MP -MF .deps/libuuid_la-isnull.Tpo -c isnull.c -o libuuid_la-isnull.o >/dev/null 2>&1
mv -f .deps/libuuid_la-isnull.Tpo .deps/libuuid_la-isnull.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-pack.lo -MD -MP -MF .deps/libuuid_la-pack.Tpo -c -o libuuid_la-pack.lo `test -f 'pack.c' || echo './'`pack.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-pack.lo -MD -MP -MF .deps/libuuid_la-pack.Tpo -c pack.c  -fPIC -DPIC -o .libs/libuuid_la-pack.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-pack.lo -MD -MP -MF .deps/libuuid_la-pack.Tpo -c pack.c -o libuuid_la-pack.o >/dev/null 2>&1
mv -f .deps/libuuid_la-pack.Tpo .deps/libuuid_la-pack.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-parse.lo -MD -MP -MF .deps/libuuid_la-parse.Tpo -c -o libuuid_la-parse.lo `test -f 'parse.c' || echo './'`parse.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-parse.lo -MD -MP -MF .deps/libuuid_la-parse.Tpo -c parse.c  -fPIC -DPIC -o .libs/libuuid_la-parse.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-parse.lo -MD -MP -MF .deps/libuuid_la-parse.Tpo -c parse.c -o libuuid_la-parse.o >/dev/null 2>&1
mv -f .deps/libuuid_la-parse.Tpo .deps/libuuid_la-parse.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-unpack.lo -MD -MP -MF .deps/libuuid_la-unpack.Tpo -c -o libuuid_la-unpack.lo `test -f 'unpack.c' || echo './'`unpack.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-unpack.lo -MD -MP -MF .deps/libuuid_la-unpack.Tpo -c unpack.c  -fPIC -DPIC -o .libs/libuuid_la-unpack.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-unpack.lo -MD -MP -MF .deps/libuuid_la-unpack.Tpo -c unpack.c -o libuuid_la-unpack.o >/dev/null 2>&1
mv -f .deps/libuuid_la-unpack.Tpo .deps/libuuid_la-unpack.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-unparse.lo -MD -MP -MF .deps/libuuid_la-unparse.Tpo -c -o libuuid_la-unparse.lo `test -f 'unparse.c' || echo './'`unparse.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-unparse.lo -MD -MP -MF .deps/libuuid_la-unparse.Tpo -c unparse.c  -fPIC -DPIC -o .libs/libuuid_la-unparse.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-unparse.lo -MD -MP -MF .deps/libuuid_la-unparse.Tpo -c unparse.c -o libuuid_la-unparse.o >/dev/null 2>&1
mv -f .deps/libuuid_la-unparse.Tpo .deps/libuuid_la-unparse.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-uuid_time.lo -MD -MP -MF .deps/libuuid_la-uuid_time.Tpo -c -o libuuid_la-uuid_time.lo `test -f 'uuid_time.c' || echo './'`uuid_time.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-uuid_time.lo -MD -MP -MF .deps/libuuid_la-uuid_time.Tpo -c uuid_time.c  -fPIC -DPIC -o .libs/libuuid_la-uuid_time.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-uuid_time.lo -MD -MP -MF .deps/libuuid_la-uuid_time.Tpo -c uuid_time.c -o libuuid_la-uuid_time.o >/dev/null 2>&1
mv -f .deps/libuuid_la-uuid_time.Tpo .deps/libuuid_la-uuid_time.Plo
/bin/sh ./libtool  --tag=CC   --mode=compile gcc -DHAVE_CONFIG_H -I.    -I. -g -O2 -MT libuuid_la-randutils.lo -MD -MP -MF .deps/libuuid_la-randutils.Tpo -c -o libuuid_la-randutils.lo `test -f 'randutils.c' || echo './'`randutils.c
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-randutils.lo -MD -MP -MF .deps/libuuid_la-randutils.Tpo -c randutils.c  -fPIC -DPIC -o .libs/libuuid_la-randutils.o
libtool: compile:  gcc -DHAVE_CONFIG_H -I. -I. -g -O2 -MT libuuid_la-randutils.lo -MD -MP -MF .deps/libuuid_la-randutils.Tpo -c randutils.c -o libuuid_la-randutils.o >/dev/null 2>&1
mv -f .deps/libuuid_la-randutils.Tpo .deps/libuuid_la-randutils.Plo
/bin/sh ./libtool  --tag=CC   --mode=link gcc -I. -g -O2 -version-info 1:0:0  -o libuuid.la -rpath /usr/lib libuuid_la-clear.lo libuuid_la-compare.lo libuuid_la-copy.lo libuuid_la-gen_uuid.lo libuuid_la-isnull.lo libuuid_la-pack.lo libuuid_la-parse.lo libuuid_la-unpack.lo libuuid_la-unparse.lo libuuid_la-uuid_time.lo libuuid_la-randutils.lo   
libtool: link: gcc -shared  -fPIC -DPIC  .libs/libuuid_la-clear.o .libs/libuuid_la-compare.o .libs/libuuid_la-copy.o .libs/libuuid_la-gen_uuid.o .libs/libuuid_la-isnull.o .libs/libuuid_la-pack.o .libs/libuuid_la-parse.o .libs/libuuid_la-unpack.o .libs/libuuid_la-unparse.o .libs/libuuid_la-uuid_time.o .libs/libuuid_la-randutils.o    -O2   -Wl,-soname -Wl,libuuid.so.1 -o .libs/libuuid.so.1.0.0
libtool: link: (cd ".libs" && rm -f "libuuid.so.1" && ln -s "libuuid.so.1.0.0" "libuuid.so.1")
libtool: link: (cd ".libs" && rm -f "libuuid.so" && ln -s "libuuid.so.1.0.0" "libuuid.so")
libtool: link: ar cru .libs/libuuid.a  libuuid_la-clear.o libuuid_la-compare.o libuuid_la-copy.o libuuid_la-gen_uuid.o libuuid_la-isnull.o libuuid_la-pack.o libuuid_la-parse.o libuuid_la-unpack.o libuuid_la-unparse.o libuuid_la-uuid_time.o libuuid_la-randutils.o
ar: `u' modifier ignored since `D' is the default (see `U')
libtool: link: ranlib .libs/libuuid.a
libtool: link: ( cd ".libs" && rm -f "libuuid.la" && ln -s "../libuuid.la" "libuuid.la" )
make[1]: Entering directory '/libuuid-1.0.3'
 ./install-sh -c -d '/usr/lib'
 /bin/sh ./libtool   --mode=install /usr/bin/install -c   libuuid.la '/usr/lib'
libtool: install: /usr/bin/install -c .libs/libuuid.so.1.0.0 /usr/lib/libuuid.so.1.0.0
libtool: install: (cd /usr/lib && { ln -s -f libuuid.so.1.0.0 libuuid.so.1 || { rm -f libuuid.so.1 && ln -s libuuid.so.1.0.0 libuuid.so.1; }; })
libtool: install: (cd /usr/lib && { ln -s -f libuuid.so.1.0.0 libuuid.so || { rm -f libuuid.so && ln -s libuuid.so.1.0.0 libuuid.so; }; })
libtool: install: /usr/bin/install -c .libs/libuuid.lai /usr/lib/libuuid.la
libtool: install: /usr/bin/install -c .libs/libuuid.a /usr/lib/libuuid.a
libtool: install: chmod 644 /usr/lib/libuuid.a
libtool: install: ranlib /usr/lib/libuuid.a
libtool: finish: PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:/sbin" ldconfig -n /usr/lib
----------------------------------------------------------------------
Libraries have been installed in:
   /usr/lib

If you ever happen to want to link against installed libraries
in a given directory, LIBDIR, you must either use libtool, and
specify the full pathname of the library, or use the `-LLIBDIR'
flag during linking and do at least one of the following:
   - add LIBDIR to the `LD_LIBRARY_PATH' environment variable
     during execution
   - add LIBDIR to the `LD_RUN_PATH' environment variable
     during linking
   - use the `-Wl,-rpath -Wl,LIBDIR' linker flag

See any operating system documentation about shared libraries for
more information, such as the ld(1) and ld.so(8) manual pages.
----------------------------------------------------------------------
 ./install-sh -c -d '/usr/lib/pkgconfig'
 /usr/bin/install -c -m 644 uuid.pc '/usr/lib/pkgconfig'
 ./install-sh -c -d '/usr/include/uuid'
 /usr/bin/install -c -m 644 uuid.h '/usr/include/uuid'
make[1]: Leaving directory '/libuuid-1.0.3'
Connecting to taskwarrior.org (134.209.106.40:80)
Connecting to taskwarrior.org (157.230.45.115:443)
writing to stdout
-                     30% |*********                       | 36337  0:00:02 ETA
-                    100% |********************************|  117k  0:00:00 ETA
written to stdout
CMake Deprecation Warning at CMakeLists.txt:4 (cmake_policy):
  The OLD behavior for policy CMP0037 will be removed from a future version
  of CMake.

  The cmake-policies(7) manual explains that the OLD behaviors of all
  policies are deprecated and that a policy should be set to OLD only under
  specific short-term circumstances.  Projects should be ported to the NEW
  behavior and not rely on setting a policy to OLD.


-- The C compiler identification is GNU 9.3.0
-- The CXX compiler identification is GNU 9.3.0
-- Check for working C compiler: /usr/bin/cc
-- Check for working C compiler: /usr/bin/cc - works
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/c++
-- Check for working CXX compiler: /usr/bin/c++ - works
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Detecting CXX compile features
-- Detecting CXX compile features - done
CMAKE_SYSTEM_NAME Linux
-- Performing Test _HAS_CXX11
-- Performing Test _HAS_CXX11 - Success
-- Performing Test _HAS_CXX0X
-- Performing Test _HAS_CXX0X - Success
-- Performing Test _HAS_GNU0X
-- Performing Test _HAS_GNU0X - Success
-- Looking for SHA1 references
-- Looking for GnuTLS
-- Found GnuTLS: /usr/lib/libgnutls.so (found version "3.6.15") 
-- Looking for libuuid
-- Looking for uuid_unparse_lower
-- Looking for uuid_unparse_lower - found
-- Found libuuid
-- Looking for timegm
-- Looking for timegm - found
-- Looking for get_current_dir_name
-- Looking for get_current_dir_name - found
-- Performing Test HAVE_TM_GMTOFF
-- Performing Test HAVE_TM_GMTOFF - Success
-- Performing Test HAVE_ST_BIRTHTIME
-- Performing Test HAVE_ST_BIRTHTIME - Failed
-- Configuring cmake.h
-- Configuring man pages
-- Configuring done
-- Generating done
-- Build files have been written to: /taskd-1.1.0
Scanning dependencies of target taskd_executable
[  3%] Building CXX object src/CMakeFiles/taskd_executable.dir/taskd.cpp.o
[  6%] Building CXX object src/CMakeFiles/taskd_executable.dir/admin.cpp.o
[  9%] Building CXX object src/CMakeFiles/taskd_executable.dir/api.cpp.o
[ 12%] Building CXX object src/CMakeFiles/taskd_executable.dir/client.cpp.o
[ 15%] Building CXX object src/CMakeFiles/taskd_executable.dir/Color.cpp.o
[ 18%] Building CXX object src/CMakeFiles/taskd_executable.dir/ConfigFile.cpp.o
[ 21%] Building CXX object src/CMakeFiles/taskd_executable.dir/config.cpp.o
[ 24%] Building CXX object src/CMakeFiles/taskd_executable.dir/daemon.cpp.o
[ 27%] Building CXX object src/CMakeFiles/taskd_executable.dir/diag.cpp.o
[ 30%] Building CXX object src/CMakeFiles/taskd_executable.dir/Database.cpp.o
[ 33%] Building CXX object src/CMakeFiles/taskd_executable.dir/Date.cpp.o
[ 36%] Building CXX object src/CMakeFiles/taskd_executable.dir/Directory.cpp.o
[ 39%] Building CXX object src/CMakeFiles/taskd_executable.dir/Duration.cpp.o
[ 42%] Building CXX object src/CMakeFiles/taskd_executable.dir/File.cpp.o
[ 45%] Building CXX object src/CMakeFiles/taskd_executable.dir/help.cpp.o
[ 48%] Building CXX object src/CMakeFiles/taskd_executable.dir/init.cpp.o
[ 51%] Building CXX object src/CMakeFiles/taskd_executable.dir/JSON.cpp.o
[ 54%] Building CXX object src/CMakeFiles/taskd_executable.dir/Log.cpp.o
[ 57%] Building CXX object src/CMakeFiles/taskd_executable.dir/Msg.cpp.o
[ 60%] Building CXX object src/CMakeFiles/taskd_executable.dir/Nibbler.cpp.o
[ 63%] Building CXX object src/CMakeFiles/taskd_executable.dir/Path.cpp.o
[ 66%] Building CXX object src/CMakeFiles/taskd_executable.dir/RX.cpp.o
[ 69%] Building CXX object src/CMakeFiles/taskd_executable.dir/Server.cpp.o
[ 72%] Building CXX object src/CMakeFiles/taskd_executable.dir/status.cpp.o
[ 75%] Building CXX object src/CMakeFiles/taskd_executable.dir/Task.cpp.o
[ 78%] Building CXX object src/CMakeFiles/taskd_executable.dir/text.cpp.o
[ 81%] Building CXX object src/CMakeFiles/taskd_executable.dir/Timer.cpp.o
[ 84%] Building CXX object src/CMakeFiles/taskd_executable.dir/TLSClient.cpp.o
In file included from /taskd-1.1.0/src/TLSClient.cpp:42:
/usr/include/sys/errno.h:1:2: warning: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      |  ^~~~~~~
[ 87%] Building CXX object src/CMakeFiles/taskd_executable.dir/TLSServer.cpp.o
In file included from /taskd-1.1.0/src/TLSServer.cpp:44:
/usr/include/sys/errno.h:1:2: warning: #warning redirecting incorrect #include <sys/errno.h> to <errno.h> [-Wcpp]
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      |  ^~~~~~~
[ 90%] Building CXX object src/CMakeFiles/taskd_executable.dir/utf8.cpp.o
[ 93%] Building CXX object src/CMakeFiles/taskd_executable.dir/util.cpp.o
[ 96%] Building CXX object src/CMakeFiles/taskd_executable.dir/wcwidth6.cpp.o
[100%] Linking CXX executable taskd
[100%] Built target taskd_executable
Install the project...
-- Install configuration: "release"
-- Installing: /usr/share/doc/taskd/NEWS
-- Installing: /usr/share/doc/taskd/ChangeLog
-- Installing: /usr/share/doc/taskd/INSTALL
-- Installing: /usr/share/doc/taskd/AUTHORS
-- Installing: /usr/share/doc/taskd/COPYING
-- Installing: /usr/bin/taskdctl
-- Installing: /usr/bin/taskd
-- Installing: /usr/share/man/man1
-- Installing: /usr/share/man/man1/taskd.1
-- Installing: /usr/share/man/man1/taskdctl.1
-- Installing: /usr/share/man/man5
-- Installing: /usr/share/man/man5/taskdrc.5
ERROR: No certtool found
ERROR: No certtool found
ERROR: No certtool found
ERROR: No certtool found
The command '/bin/sh -c apk add --update build-base                      cmake                      gnutls                      gnutls-dev                      libstdc++     && wget -O- http://downloads.sourceforge.net/project/libuuid/libuuid-1.0.3.tar.gz | tar xz         && cd libuuid-1.0.3         && ./configure --prefix=/usr         && make install         && cd ..         && rm -rf libuuid-1.0.3     && wget -O- http://taskwarrior.org/download/taskd-1.1.0.tar.gz | tar xz         && cd taskd-1.1.0         && cmake -DCMAKE_INSTALL_PREFIX:PATH=/usr -DCMAKE_BUILD_TYPE=release .         && make install         && cd pki         && ./generate         && mkdir -p $TASKDDATA         && mv *.pem $TASKDDATA         && cd ../..         && rm -rf taskd-1.1.0     && apk del --purge build-base                        cmake                        gnutls-dev     && rm -rf /var/cache/apk/*' returned a non-zero code: 1
```