### PR TITLE
Fixed healthcheck for CMAK

### DIFF
--- a/cmak/Dockerfile
+++ b/cmak/Dockerfile
@@ -36,4 +36,4 @@ EXPOSE 9000
 ENTRYPOINT ["bin/cmak"]
 CMD ["-Dconfig.file=conf/application.conf", "-Dhttp.port=9000", "-Dpidfile.path=/dev/null"]
 
-HEALTHCHECK CMD curl -f http://127.0.0.1/api/health || exit 1
+HEALTHCHECK CMD curl -f http://127.0.0.1:9000/api/health || exit 1


### PR DESCRIPTION
Hello!

Here's a quick fix for CMAK healthcheck (fixed the port number in the URL).