### PR TITLE
Add beautifulsoup4 as a dependency

### DIFF
--- a/urlwatch/Dockerfile
+++ b/urlwatch/Dockerfile
@@ -18,16 +18,17 @@ RUN set -xe \
                           py3-pip          \
                           python3          \
                           python3-dev      \
-    && pip3 install appdirs       \
-                    cssselect     \
-                    keyring       \
-                    lxml          \
-                    minidb        \
-                    pyyaml        \
-                    requests      \
-                    chump         \
-                    pushbullet.py \
-                    urlwatch      \
+    && pip3 install appdirs        \
+                    cssselect      \
+                    keyring        \
+                    lxml           \
+                    minidb         \
+                    pyyaml         \
+                    requests       \
+                    chump          \
+                    beautifulsoup4 \
+                    pushbullet.py  \
+                    urlwatch       \
     && apk del build-base  \
                libffi-dev  \
                libxml2-dev \


### PR DESCRIPTION
So using filters like `beautify` won't result in the following error:

```
Traceback (most recent call last):
  File "/usr/lib/python3.8/site-packages/urlwatch/handler.py", line 120, in process
    data = FilterBase.process(filter_kind, subfilter, self, data)
  File "/usr/lib/python3.8/site-packages/urlwatch/filters.py", line 180, in process
    return filtercls(state.job, state).filter(data, subfilter)
  File "/usr/lib/python3.8/site-packages/urlwatch/filters.py", line 276, in filter
    raise ImportError('Please install BeautifulSoup')
ImportError: Please install BeautifulSoup
```