### PR TITLE
chore: Use --no-cache-dir flag to pip in Dockerfiles, to save space

### DIFF
--- a/airflow/Dockerfile
+++ b/airflow/Dockerfile
@@ -20,8 +20,8 @@ RUN set -xe \
         mariadb-dev \
         postgresql-dev \
         python3-dev \
-    && pip install cython numpy psycopg2-binary \
-    && pip install apache-airflow[${AIRFLOW_EXTRAS}]==${AIRFLOW_VERSION} \
+    && pip install --no-cache-dir cython numpy psycopg2-binary \
+    && pip install --no-cache-dir apache-airflow[${AIRFLOW_EXTRAS}]==${AIRFLOW_VERSION} \
     && apk del \
         build-base \
         cyrus-sasl-dev \

--- a/django-cms/Dockerfile
+++ b/django-cms/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /app
 
 RUN set -xe \
     && apk add -U py-pillow tzdata \
-    && pip install djangocms-installer \
+    && pip install --no-cache-dir djangocms-installer \
     && mkdir -p data \
     && djangocms --db sqlite://localhost/data/project.db \
                  --filer \

--- a/docker-compose-arm/Dockerfile
+++ b/docker-compose-arm/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe \
                           upx-ucl \
                           zlib1g-dev \
     && curl https://bootstrap.pypa.io/get-pip.py | python3 \
-    && pip install docker-compose==$DOCKER_COMPOSE_VERSION \
+    && pip install --no-cache-dir docker-compose==$DOCKER_COMPOSE_VERSION \
                    pyinstaller==$PYINSTALLER_VERSION \
     && cd /usr/local/lib/python3.7/dist-packages \
     && mkdir -p bin \

--- a/elastalert/Dockerfile
+++ b/elastalert/Dockerfile
@@ -25,7 +25,7 @@ RUN set -xe \
         musl-dev \
         openssl-dev \
         python3-dev \
-    && pip install elastalert==${ELASTALERT_VERSION} \
+    && pip install --no-cache-dir elastalert==${ELASTALERT_VERSION} \
     && mkdir -p rules \
     && curl -sSL https://github.com/Yelp/elastalert/raw/${ELASTALERT_VERSION}/config.yaml.example > config.yaml \
     && apk del .build-deps

--- a/errbot/Dockerfile
+++ b/errbot/Dockerfile
@@ -14,8 +14,8 @@ RUN set -xe \
                           openssl-dev \
                           python3 \
                           python3-dev \
-    && pip3 install -U pip \
-    && pip3 install errbot \
+    && pip3 install --no-cache-dir -U pip \
+    && pip3 install --no-cache-dir errbot \
                     hypchat \
                     irc \
                     pyasn1 \

--- a/errbot/arm/Dockerfile
+++ b/errbot/arm/Dockerfile
@@ -14,8 +14,8 @@ RUN set -xe \
                           openssl-dev \
                           python3 \
                           python3-dev \
-    && pip3 install -U pip \
-    && pip3 install errbot \
+    && pip3 install --no-cache-dir -U pip \
+    && pip3 install --no-cache-dir errbot \
                     hypchat \
                     irc \
                     pyasn1 \

--- a/fteproxy/Dockerfile
+++ b/fteproxy/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
                   python \
                   python-dev \
                   py-pip \
-    && pip install fteproxy \
+    && pip install --no-cache-dir fteproxy \
     && apk del build-base \
                gmp-dev \
                python-dev \

--- a/fteproxy/arm/Dockerfile
+++ b/fteproxy/arm/Dockerfile
@@ -13,7 +13,7 @@ RUN set -xe \
                   python \
                   python-dev \
                   py-pip \
-    && pip install fteproxy \
+    && pip install --no-cache-dir fteproxy \
     && apk del build-base \
                gmp-dev \
                python-dev \

--- a/glances/Dockerfile
+++ b/glances/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
                           python-dev \
                           wireless-tools \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install "glances[action,batinfo,browser,cpuinfo,chart,docker,export,folders,gpu,ip,raid,snmp,web,wifi]" \
+    && pip install --no-cache-dir "glances[action,batinfo,browser,cpuinfo,chart,docker,export,folders,gpu,ip,raid,snmp,web,wifi]" \
     && apt-get remove -y build-essential \
                          curl \
                          libfreetype6-dev \

--- a/glances/arm/Dockerfile
+++ b/glances/arm/Dockerfile
@@ -19,7 +19,7 @@ RUN set -xe \
                           python-dev \
                           wireless-tools \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install "glances[action,batinfo,browser,cpuinfo,chart,docker,export,folders,gpu,ip,raid,snmp,web,wifi]" \
+    && pip install --no-cache-dir "glances[action,batinfo,browser,cpuinfo,chart,docker,export,folders,gpu,ip,raid,snmp,web,wifi]" \
     && apt-get remove -y build-essential \
                          curl \
                          libfreetype6-dev \

--- a/graphite/Dockerfile
+++ b/graphite/Dockerfile
@@ -24,12 +24,12 @@ RUN set -xe \
                python3 \
                python3-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 \
-    && pip3 install gunicorn supervisor \
-    && pip3 install --install-option=--prefix=/opt/graphite \
+    && pip3 install --no-cache-dir gunicorn supervisor \
+    && pip3 install --no-cache-dir --install-option=--prefix=/opt/graphite \
                     --install-option=--install-lib=/opt/graphite/lib \
                     whisper==$GRAPHITE_VERSION \
                     carbon==$GRAPHITE_VERSION \
-    && pip3 install --install-option=--prefix=/opt/graphite \
+    && pip3 install --no-cache-dir --install-option=--prefix=/opt/graphite \
                     --install-option=--install-lib=/opt/graphite/webapp \
                     graphite-web==$GRAPHITE_VERSION \
     && cd ./webapp \

--- a/hcfg/Dockerfile
+++ b/hcfg/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt/hcfg
 
 RUN set -xe \
     && apk add --no-cache curl git python3 \
-    && pip3 install gitpython \
+    && pip3 install --no-cache-dir gitpython \
     && mkdir -p bin etc \
     && curl -sSL https://raw.githubusercontent.com/danielperna84/hass-configurator/master/configurator.py > bin/hcfg \
     && curl -sSL https://raw.githubusercontent.com/danielperna84/hass-configurator/master/settings.conf > etc/hcfg.conf \

--- a/hcfg/arm/Dockerfile
+++ b/hcfg/arm/Dockerfile
@@ -9,7 +9,7 @@ WORKDIR /opt/hcfg
 
 RUN set -xe \
     && apk add --no-cache curl git python3 \
-    && pip3 install gitpython \
+    && pip3 install --no-cache-dir gitpython \
     && mkdir -p bin etc \
     && curl -sSL https://raw.githubusercontent.com/danielperna84/hass-configurator/master/configurator.py > bin/hcfg \
     && curl -sSL https://raw.githubusercontent.com/danielperna84/hass-configurator/master/settings.conf > etc/hcfg.conf \

--- a/httpbin/Dockerfile
+++ b/httpbin/Dockerfile
@@ -5,7 +5,7 @@
 FROM vimagick/python:3
 MAINTAINER kev <noreply@easypi.pro>
 
-RUN pip install gunicorn httpbin
+RUN pip install --no-cache-dir gunicorn httpbin
 
 EXPOSE 80
 

--- a/ludwig/Dockerfile
+++ b/ludwig/Dockerfile
@@ -1,4 +1,4 @@
 FROM tensorflow/tensorflow:latest-py3
-RUN pip install ludwig[full]
+RUN pip install --no-cache-dir ludwig[full]
 WORKDIR /data
 ENTRYPOINT ["ludwig"]

--- a/luigi/Dockerfile
+++ b/luigi/Dockerfile
@@ -14,7 +14,7 @@ WORKDIR $LUIGI_HOME_DIR
 
 RUN set -xe \
     && apk add --no-cache python3 \
-    && pip3 install luigi \
+    && pip3 install --no-cache-dir luigi \
     && mkdir -p etc log run var \
     && touch $LUIGI_CONFIG_PATH
 

--- a/mediagoblin/Dockerfile
+++ b/mediagoblin/Dockerfile
@@ -61,7 +61,7 @@ RUN set -xe \
     && ./configure \
     && make \
     && bin/easy_install flup==1.0.3.dev-20110405 \
-    && bin/pip install scikits.audiolab \
+    && bin/pip install --no-cache-dir scikits.audiolab \
     && ln -s /var/lib/mediagoblin user_dev \
     && cp -av mediagoblin.ini mediagoblin_local.ini \
     && cp -av paste.ini paste_local.ini \

--- a/ndscheduler/Dockerfile
+++ b/ndscheduler/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER EasyPi Software Foundation
 
 RUN set -xe \
     && apk add --no-cache bash sqlite \
-    && pip install ndscheduler requests
+    && pip install --no-cache-dir ndscheduler requests
 
 WORKDIR /opt/ndscheduler
 VOLUME /opt/ndscheduler

--- a/obfsproxy/Dockerfile
+++ b/obfsproxy/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER kev <noreply@easypi.pro>
 RUN set -xe \
     && apk add --no-cache build-base curl python python-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install obfsproxy \
+    && pip install --no-cache-dir obfsproxy \
     && apk del build-base curl python-dev
 
 ENV LOG_MIN_SEVERITY info

--- a/obfsproxy/Dockerfile.debian
+++ b/obfsproxy/Dockerfile.debian
@@ -9,7 +9,7 @@ RUN set -xe \
     && apt-get update \
     && apt-get install -y build-essential curl python python-dev \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install obfsproxy \
+    && pip install --no-cache-dir obfsproxy \
     && apt-get purge -y build-essential python-dev \
     && apt-get autoremove -y \
     && apt-get clean -y \

--- a/obfsproxy/arm/Dockerfile
+++ b/obfsproxy/arm/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER EasyPi Software Foundation
 RUN set -xe \
     && apk add --no-cache build-base curl python python-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install obfsproxy \
+    && pip install --no-cache-dir obfsproxy \
     && apk del build-base curl python-dev
 
 ENV LOG_MIN_SEVERITY info

--- a/oled-arm/Dockerfile
+++ b/oled-arm/Dockerfile
@@ -16,7 +16,7 @@ RUN set -xe \
                           jpeg \
                           jpeg-dev \
     && curl https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install luma.oled \
+    && pip install --no-cache-dir luma.oled \
     && apk del --purge build-base \
                        curl \
                        linux-headers \

--- a/proxyhub/Dockerfile
+++ b/proxyhub/Dockerfile
@@ -24,7 +24,7 @@ ADD http://download.dnscrypt.org/dnscrypt-proxy/dnscrypt-proxy-1.4.3.tar.gz /tmp
 WORKDIR /tmp/pkgs/
 RUN chmod +x /usr/local/bin/jq
 RUN python get-pip.py
-RUN pip install supervisor shadowsocks
+RUN pip install --no-cache-dir supervisor shadowsocks
 RUN tar xzf libsodium-1.0.2.tar.gz && \
     cd libsodium-1.0.2 && \
     ./configure && \

--- a/routersploit/Dockerfile
+++ b/routersploit/Dockerfile
@@ -20,7 +20,7 @@ RUN set -xe \
                   tar \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
     && curl -sSL https://github.com/reverse-shell/routersploit/archive/master.tar.gz | tar xz --strip 1 \
-    && pip install -r requirements.txt \
+    && pip install --no-cache-dir -r requirements.txt \
     && apk del bash \
                build-base \
                curl \

--- a/routersploit/Dockerfile.arm
+++ b/routersploit/Dockerfile.arm
@@ -20,7 +20,7 @@ RUN set -xe \
                   tar \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
     && curl -sSL https://github.com/reverse-shell/routersploit/archive/master.tar.gz | tar xz --strip 1 \
-    && pip install -r requirements.txt \
+    && pip install --no-cache-dir -r requirements.txt \
     && apk del bash \
                build-base \
                curl \

--- a/salt-master/Dockerfile
+++ b/salt-master/Dockerfile
@@ -10,7 +10,7 @@ RUN apt-get update \
     && curl -sSL https://bootstrap.saltstack.com | bash -s -- -M -N -S -X \
     && apt-get install -y salt-ssh \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install httpie ipython \
+    && pip install --no-cache-dir httpie ipython \
     && rm -rf /var/lib/apt/lists/*
 
 VOLUME /etc/salt /srv/salt

--- a/scrapyd/Dockerfile
+++ b/scrapyd/Dockerfile
@@ -38,7 +38,7 @@ RUN set -xe \
                           zlib1g \
                           zlib1g-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
+    && pip install --no-cache-dir git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
                    git+https://github.com/scrapy/scrapyd.git@$SCRAPYD_VERSION \
                    git+https://github.com/scrapy/scrapyd-client.git \
                    git+https://github.com/scrapinghub/scrapy-splash.git \

--- a/scrapyd/arm/Dockerfile
+++ b/scrapyd/arm/Dockerfile
@@ -39,7 +39,7 @@ RUN set -xe \
                           zlib1g \
                           zlib1g-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 \
-    && pip install git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
+    && pip install --no-cache-dir git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
                    git+https://github.com/scrapy/scrapyd.git@$SCRAPYD_VERSION \
                    git+https://github.com/scrapy/scrapyd-client.git \
                    git+https://github.com/scrapinghub/scrapy-splash.git \

--- a/scrapyd/onbuild/Dockerfile
+++ b/scrapyd/onbuild/Dockerfile
@@ -10,6 +10,6 @@ ONBUILD RUN cd /etc/scrapyd; \
             [ -f packages.txt -o -f dependencies.txt ] && apt-get update; \
             [ -f packages.txt ] && xargs -r apt-get install -y < packages.txt; \
             [ -f dependencies.txt ] && xargs -r apt-get install -y < dependencies.txt; \
-            [ -f requirements.txt ] && pip install -r requirements.txt; \
+            [ -f requirements.txt ] && pip install --no-cache-dir -r requirements.txt; \
             [ -f dependencies.txt ] && xargs -r apt-get purge -y --auto-remove < dependencies.txt; \
             [ -f packages.txt -o -f dependencies.txt ] && rm -rf /var/lib/apt/lists/*

--- a/scrapyd/py3/Dockerfile
+++ b/scrapyd/py3/Dockerfile
@@ -39,7 +39,7 @@ RUN set -xe \
                           zlib1g \
                           zlib1g-dev \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python3 \
-    && pip install git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
+    && pip install --no-cache-dir git+https://github.com/scrapy/scrapy.git@$SCRAPY_VERSION \
                    git+https://github.com/scrapy/scrapyd.git@$SCRAPYD_VERSION \
                    git+https://github.com/scrapy/scrapyd-client.git \
                    git+https://github.com/scrapinghub/scrapy-splash.git \

--- a/shadowsocks/Dockerfile
+++ b/shadowsocks/Dockerfile
@@ -9,7 +9,7 @@ RUN set -ex \
     && echo 'http://nl.alpinelinux.org/alpine/edge/main' >> /etc/apk/repositories \
     && apk add -U curl libsodium python \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install shadowsocks \
+    && pip install --no-cache-dir shadowsocks \
     && apk del curl \
     && rm -rf /var/cache/apk/*
 

--- a/shadowsocks/arm/Dockerfile
+++ b/shadowsocks/arm/Dockerfile
@@ -8,7 +8,7 @@ MAINTAINER kev <noreply@easypi.pro>
 RUN set -ex \
     && apk add -U curl libsodium python \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install shadowsocks \
+    && pip install --no-cache-dir shadowsocks \
     && apk del curl \
     && rm -rf /var/cache/apk/*
 

--- a/slacker/Dockerfile
+++ b/slacker/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER EasyPi Software Foundation
 
 RUN set -xe \
  && apk add --no-cache curl \
- && pip install aiosmtpd atpublic pyslack pyyaml requests \
+ && pip install --no-cache-dir aiosmtpd atpublic pyslack pyyaml requests \
  && cd /usr/local/lib/python3.9/site-packages/ \
  && wget https://github.com/ont/slacker/raw/master/handler.py
 

--- a/snort/Dockerfile
+++ b/snort/Dockerfile
@@ -23,7 +23,7 @@ RUN set -xe \
                 /usr/local/lib/snort_dynamicrules \
     && ln -s /usr/lib64/libdnet.so.1 /usr/local/lib/libdnet.1 \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install idstools \
+    && pip install --no-cache-dir idstools \
     && yum clean all
 
 COPY data/snort.conf /etc/snort/snort.conf

--- a/tmail/Dockerfile
+++ b/tmail/Dockerfile
@@ -10,7 +10,7 @@ RUN apk add --update build-base \
                      python-dev \
                      openssl    \
     && wget -O- https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install twisted \
+    && pip install --no-cache-dir twisted \
     && apk del --purge build-base \
                        python-dev \
                        openssl    \

--- a/tor/Dockerfile
+++ b/tor/Dockerfile
@@ -16,7 +16,7 @@ RUN set -xe \
                           python-dev \
                           tor \
     && curl -sSL https://bootstrap.pypa.io/get-pip.py | python \
-    && pip install fteproxy \
+    && pip install --no-cache-dir fteproxy \
                    obfsproxy \
     && GOPATH=/tmp/obfs4 go get git.torproject.org/pluggable-transports/obfs4.git/obfs4proxy \
         && mv /tmp/obfs4/bin/obfs4proxy /usr/bin \

--- a/urlwatch/Dockerfile
+++ b/urlwatch/Dockerfile
@@ -18,7 +18,7 @@ RUN set -xe \
                           py3-pip          \
                           python3          \
                           python3-dev      \
-    && pip3 install appdirs        \
+    && pip3 install --no-cache-dir appdirs        \
                     cssselect      \
                     keyring        \
                     lxml           \

--- a/vnc2flv/Dockerfile
+++ b/vnc2flv/Dockerfile
@@ -10,7 +10,7 @@ RUN set -xe \
                           python \
                           python-dev \
                           py-pip \
-    && pip install vnc2flv \
+    && pip install --no-cache-dir vnc2flv \
     && apk del --purge build-base \
                        python-dev \
                        py-pip

--- a/wafw00f/Dockerfile
+++ b/wafw00f/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER EasyPi Software Foundation
 
 RUN set -xe \
     && apk add --no-cache python3 \
-    && pip3 install wafw00f
+    && pip3 install --no-cache-dir wafw00f
 
 ENTRYPOINT ["wafw00f"]
 CMD ["--help"]

--- a/youtube/youtube-dl/Dockerfile
+++ b/youtube/youtube-dl/Dockerfile
@@ -10,7 +10,7 @@ RUN set -xe \
                           ffmpeg \
                           openssl \
                           aria2 \
-    && pip3 install youtube-dl
+    && pip3 install --no-cache-dir youtube-dl
 
 # Try to run it so we know it works
 RUN youtube-dl --version

--- a/youtube/youtube-worker/Dockerfile
+++ b/youtube/youtube-worker/Dockerfile
@@ -7,7 +7,7 @@ MAINTAINER kev <noreplay@easypi.pro>
 
 RUN apk add -U ca-certificates py-pip \
     && rm -rf /var/cache/apk/* \
-    && pip install redis youtube-dl
+    && pip install --no-cache-dir redis youtube-dl
 
 COPY worker.py /code/
 VOLUME /data


### PR DESCRIPTION
Using "--no-cache-dir" flag in pip install ,make sure dowloaded packages
by pip don't cached on system . This is a best practise which make sure
to fetch ftom repo instead of using local cached one . Further , in case
of Docker Containers , by restricing caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>