### PR TITLE
Fix broken Star History chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -608,5 +608,5 @@ complete -F __enter enter
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=vimagick/dockerfiles&type=Timeline)](https://star-history.com/#vimagick/dockerfiles&Timeline)
+[![Star History Chart](https://star-history.dera.page/svg?repos=vimagick/dockerfiles&type=Timeline)](https://star-history.dera.page/#vimagick/dockerfiles&Timeline)
 


### PR DESCRIPTION
The Star History chart in the README is currently broken because the upstream chart can no longer retrieve stargazer data from the GitHub API. This switches the chart and its link to a working instance that follows the same data source so the chart displays again.

Fixes the chart only; no other changes are included.